### PR TITLE
Open tabs with openerTabId

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -41,6 +41,7 @@ function openUrls( urllist, tab ) {
       {
         windowId: tab.windowId,
         index: ++tabId,
+        openerTabId: tab.id,
         url: url,
         active: false
       }


### PR DESCRIPTION
Some addons (ex. Tree Style Tab) detect relation of tabs based on the information, thus this change will help collaboration with such addons. How about this?

By the way, `openerTabId` is supported on Firefox 57 and later. If this project aims to support Firefox ESR52, some more changes are needed to switch options for `browser.tabs.create()` because `openerTabId` raises an error on those old Firefox.