### PR TITLE
limit the number of concurrently loading tabs

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -26,7 +26,10 @@
   ],
 
   "background": {
-    "scripts": ["src/background.js"]
+    "scripts": [
+      "src/defaults.js",
+      "src/background.js"
+    ]
   },
 
   "content_scripts": [

--- a/options.html
+++ b/options.html
@@ -1,16 +1,47 @@
 <!DOCTYPE html>
 
 <html>
-  <head>
-    <meta charset="utf-8"/>
-  </head>
+<head>
+<meta charset="utf-8"/>
 
-  <body>
-    <form>
-      <label>Minimum interval between opening pages (milliseconds)</label>
-      <input type="number" id="interval"/>
-      <button type="submit">Save</button>
-    </form>
-    <script src="src/options.js"></script>
-  </body>
+<style>
+
+/* https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_styles */
+
+.panel-formElements-item {
+  flex-direction: column;
+  align-items: start;
+}
+
+.panel-formElements-item label {
+  margin-bottom: 6px;
+}
+
+</style>
+</head>
+
+<body>
+  <form>
+    <div class="panel-section panel-section-formElements">
+      <div class="panel-formElements-item">
+        <label for="maxLoading">Maximum concurrently loading tabs (0 for no limit)</label>
+        <input id="maxLoading" type="number" min="0" />
+      </div>
+      <div class="panel-formElements-item">
+        <label for="interval">Interval between opening tabs (milliseconds)</label>
+        <input id="interval" type="number" min="1" />
+      </div>
+      <div class="panel-formElements-item">
+        <label for="loadTimeout">Tab loading timeout (seconds)</label>
+        <input id="loadTimeout" type="number" min="1" />
+      </div>
+      <div class="panel-formElements-item">
+        <button type="submit" class="browser-style default">Save</button>
+      </div>
+    </div>
+  </form>
+  <script src="src/defaults.js"></script>
+  <script src="src/options.js"></script>
+</body>
+
 </html>

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,0 +1,6 @@
+// eslint-disable-next-line no-unused-vars
+const DEFAULTS = {
+  maxLoading: 4,
+  interval: 100, // Milliseconds
+  loadTimeout: 30 // Seconds
+};

--- a/src/options.js
+++ b/src/options.js
@@ -1,21 +1,23 @@
-function saveOptions(e) {
-  browser.storage.sync.set({
-    interval: document.querySelector("#interval").value
-  });
+/* global DEFAULTS */
+
+async function saveOptions(e) {
   e.preventDefault();
+
+  const options = {};
+  Object.keys(DEFAULTS).forEach(key => {
+    options[key] = document.querySelector(`#${key}`).value;
+  });
+
+  await browser.storage.sync.set(options);
 }
 
-function restoreOptions() {
-  var storageItem = browser.storage.managed.get('interval');
-  storageItem.then((res) => {
-    document.querySelector("#managed-interval").innerText = res.interval;
-  });
+async function restoreOptions() {
+  const options = await browser.storage.sync.get(DEFAULTS);
 
-  var gettingItem = browser.storage.sync.get('interval');
-  gettingItem.then((res) => {
-    document.querySelector("#interval").value = res.interval || 100;
+  Object.keys(DEFAULTS).forEach(key => {
+    document.querySelector(`#${key}`).value = options[key];
   });
 }
 
 document.addEventListener('DOMContentLoaded', restoreOptions);
-document.querySelector("form").addEventListener("submit", saveOptions);
+document.querySelector('form').addEventListener('submit', saveOptions);


### PR DESCRIPTION
I sometimes open a lot links using this extension, which makes my browser grind to a halt.

So I added a limit how many tabs are opened/loading at once. Now the default maximum loading tabs is 4 (just a nice round number), but the old no-limit functionality is still available if the limit is set to 0. There's also a timeout for tab "loading", so if the tab loads slowly, other links/tabs still get opened after a timeout.

Some random notes/thoughts:

* Is three preferences too many, maybe. Some of them could just be hard-coded values.
* Queue behavior was changed a bit: Each link batch is now opened next to its opener tab (lastTab).
* I removed the re-try from openTab(). Not sure how it could succeed if the first try failed.
* I removed openerTabId from browser.tabs.create(). Was there a purpose for it.
* I tried preserve existing style and naming. xo warnings fixed.
* UI design is not really my thing, but options.html looks reasonable in Linux.